### PR TITLE
Use ES6 modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -196,9 +196,9 @@
       }
     },
     "@mozilla/rally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/rally/-/rally-0.1.0.tgz",
-      "integrity": "sha512-v7KcL/9QhIHFWkCTHjSvCeRHAQKUQXawkTRluSQNtHdV7vM/lJf5r9XhMMMeHDfvvorwouGVLsisQbapy0XZ3Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/rally/-/rally-0.2.0.tgz",
+      "integrity": "sha512-2fYHdEWy+tOghzXsELqQ9BPIMwk8XiXJ2ueoPHlKMKrzTeH7QoaM6J2TLaK1CSdWbQWle2THIOZApngPFk1ylA==",
       "dev": true
     },
     "@rollup/plugin-commonjs": {
@@ -986,6 +986,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.3",
@@ -2552,6 +2562,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -7280,6 +7297,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch-bundled": "web-ext run --watch-file dist/background.js"
   },
   "devDependencies": {
-    "@mozilla/rally": "^0.1.0",
+    "@mozilla/rally": "^0.2.0",
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^10.0.0",
     "@rollup/plugin-replace": "^2.3.4",

--- a/src/ExampleModule.js
+++ b/src/ExampleModule.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-module.exports = {
-    initialize() {
-        console.log('example module initialized.');
-    },
-  };
+export function initialize() {
+    console.log("example module initialized.");
+}

--- a/src/background.js
+++ b/src/background.js
@@ -2,16 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-window.browser = require("webextension-polyfill");
+import "webextension-polyfill";
 
-const Rally = require("@mozilla/rally");
-const rally = new Rally();
+import Rally from "@mozilla/rally";
 
 // ... Add more implementation here!
 
-const ExampleModule = require('./ExampleModule');
-ExampleModule.initialize();
+import {
+  initialize as exampleInitialize
+} from './ExampleModule';
+exampleInitialize();
 
+const rally = new Rally();
 rally.initialize(
   // A sample key id used for encrypting data.
   "sample-invalid-key-id",

--- a/src/content-script.js
+++ b/src/content-script.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-window.browser = require("webextension-polyfill");
+import "webextension-polyfill";
 
 // ... Add more implementation here!
 


### PR DESCRIPTION
Fixes #38 .

This changes the template to use the most recent version of `rally.js` and converts the sample module to use ES6 modules.

I manually tested this locally.